### PR TITLE
feat: Primary keys and sorting for incremental replication

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,9 @@
                 "--config",
                 ".secrets/config.json",
                 "--state",
-                ".secrets/state.json"
+                ".secrets/state.json",
+                ">",
+                "/dev/null"
             ],
             "python": "${command:python.interpreterPath}",
             "justMyCode": false

--- a/tap_dataverse/streams.py
+++ b/tap_dataverse/streams.py
@@ -45,6 +45,8 @@ class DataverseTableStream(DataverseStream):
         self.replication_key = stream_config.get(
             "replication_key", tap.config.get("replication_key", "")
         )
+        
+        self.is_sorted = True
 
     @property
     def http_headers(self) -> dict:

--- a/tap_dataverse/streams.py
+++ b/tap_dataverse/streams.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Iterable
 from urllib.parse import parse_qsl
 
 from singer_sdk.helpers.jsonpath import extract_jsonpath
+from singer_sdk.streams.core import REPLICATION_INCREMENTAL
 
 from tap_dataverse.auth import DataverseAuthenticator
 from tap_dataverse.client import DataverseStream
@@ -46,7 +47,18 @@ class DataverseTableStream(DataverseStream):
             "replication_key", tap.config.get("replication_key", "")
         )
         
-        self.is_sorted = True
+    @property
+    def is_sorted(self) -> bool:
+        """Expect stream to be sorted.
+
+        When `True`, incremental streams will attempt to resume if unexpectedly
+        interrupted.
+
+        Returns:
+            `True` if stream is sorted. Defaults to `False`.
+        """
+        # Set is sorted based on INCREMENTAL stream replication type
+        return self.replication_method == REPLICATION_INCREMENTAL
 
     @property
     def http_headers(self) -> dict:

--- a/tap_dataverse/tap.py
+++ b/tap_dataverse/tap.py
@@ -150,10 +150,13 @@ class TapDataverse(Tap):
             attributes = discovery_stream.get_records(context=None)
 
             properties = th.PropertiesList()
+            primary_keys = []
 
             for attribute in attributes:
                 for stream_property in self.attribute_to_properties(attribute):
                     properties.append(stream_property)
+                if attribute['IsPrimaryId']:
+                    primary_keys.append(attribute['LogicalName'])
 
             # Repoint the discovery stream to find the EntitySetName required in the url
             # which accesses the table
@@ -174,6 +177,8 @@ class TapDataverse(Tap):
                 entity_set_name=entity_set_name,
                 schema=properties.to_dict(),
             )
+
+            discovered_stream.primary_keys = primary_keys
 
             discovered_streams.append(discovered_stream)
 


### PR DESCRIPTION
- Sets primary keys based on the `IsPrimaryId` key in the Attributes response
- Sets is_sorted for all incremental replication to enable interrupted streams to be resumed